### PR TITLE
Add metatransactions to RSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ export SOLC_VERSION = 0.5.7
 root_contracts := Basket Manager SwapProposal WeightProposal Vault ProposalFactory
 rsv_contracts := Reserve ReserveEternalStorage
 test_contracts := BasicOwnable ReserveV2 ManagerV2 BasicERC20 VaultV2 BasicTxFee
-contracts := $(root_contracts) $(rsv_contracts) $(test_contracts) ## All contract names
+oz_libraries := ECDSA
+contracts := $(root_contracts) $(rsv_contracts) $(test_contracts) $(oz_libraries) ## All contract names
 
 sol := $(shell find contracts -name '*.sol' -not -name '.*' ) ## All Solidity files
 json := $(foreach contract,$(contracts),evm/$(contract).json) ## All JSON files
@@ -81,6 +82,9 @@ evm/WeightProposal.json: contracts/Proposal.sol $(sol)
 
 evm/Vault.json: contracts/Vault.sol $(sol)
 	$(call solc,100000)
+
+evm/ECDSA.json: contracts/zeppelin/utils/ECDSA.sol $(sol)
+	$(call solc,1000000)
 
 evm/Reserve.json: contracts/rsv/Reserve.sol $(sol)
 	$(call solc,1000000)

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,9 @@ export REPO_DIR = $(shell pwd)
 export SOLC_VERSION = 0.5.7
 
 root_contracts := Basket Manager SwapProposal WeightProposal Vault ProposalFactory
-rsv_contracts := Reserve ReserveEternalStorage
+rsv_contracts := Reserve ReserveEternalStorage Relayer
 test_contracts := BasicOwnable ReserveV2 ManagerV2 BasicERC20 VaultV2 BasicTxFee
-oz_libraries := ECDSA
-contracts := $(root_contracts) $(rsv_contracts) $(test_contracts) $(oz_libraries) ## All contract names
+contracts := $(root_contracts) $(rsv_contracts) $(test_contracts) ## All contract names
 
 sol := $(shell find contracts -name '*.sol' -not -name '.*' ) ## All Solidity files
 json := $(foreach contract,$(contracts),evm/$(contract).json) ## All JSON files
@@ -83,7 +82,7 @@ evm/WeightProposal.json: contracts/Proposal.sol $(sol)
 evm/Vault.json: contracts/Vault.sol $(sol)
 	$(call solc,100000)
 
-evm/ECDSA.json: contracts/zeppelin/utils/ECDSA.sol $(sol)
+evm/Relayer.json: contracts/rsv/Relayer.sol $(sol)
 	$(call solc,1000000)
 
 evm/Reserve.json: contracts/rsv/Reserve.sol $(sol)

--- a/contracts/rsv/IRSV.sol
+++ b/contracts/rsv/IRSV.sol
@@ -15,4 +15,7 @@ interface IRSV {
     function decimals() external view returns(uint8);
     function mint(address, uint256) external;
     function burnFrom(address, uint256) external;
+    function relayTransfer(address, address, uint256) external returns(bool);
+    function relayTransferFrom(address, address, address, uint256) external returns(bool);
+    function relayApprove(address, address, uint256) external returns(bool);
 }

--- a/contracts/rsv/Relayer.sol
+++ b/contracts/rsv/Relayer.sol
@@ -1,0 +1,127 @@
+pragma solidity 0.5.7;
+
+import "./IRSV.sol";
+import "../ownership/Ownable.sol";
+import "../zeppelin/utils/ECDSA.sol";
+
+contract Relayer is Ownable {
+
+    IRSV public trustedRSV;
+    mapping(address => uint) public nonce;
+
+    event RSVChanged(address indexed oldRSVAddr, address indexed newRSVAddr);
+    event TransferForwarded(bytes sig, address indexed from, address indexed to, uint256 indexed amount, uint256 fee);
+    event TransferFromForwarded(bytes sig, address indexed spender, address indexed holder, address indexed to, uint256 amount, uint256 fee);
+    event ApproveForwarded(bytes sig, address indexed holder, address indexed spender, uint256 indexed amount, uint256 fee);
+    event FeeTaken(address indexed from, address indexed to, uint256 indexed value);
+
+    constructor() public {}
+
+    /// Set the Reserve contract address.
+    function setRSV(address newTrustedRSV) external onlyOwner {
+        emit RSVChanged(address(trustedRSV), newTrustedRSV);
+        trustedRSV = IRSV(newTrustedRSV);
+    }
+
+    // note that `fee` is not deducted from `amount`.
+    function forwardTransfer(
+        bytes calldata sig, 
+        address from,
+        address to,
+        uint256 amount,
+        uint256 fee
+    )
+        external
+    {
+        bytes32 hash = keccak256(abi.encodePacked(
+            address(trustedRSV),
+            "transfer",
+            from,
+            to,
+            amount,
+            fee,
+            nonce[from]
+        ));
+        nonce[from]++;
+
+        bytes32 ethMessageHash = ECDSA.toEthSignedMessageHash(hash);
+        address recoveredSigner = ECDSA.recover(ethMessageHash, sig);
+        require(recoveredSigner == from, "invalid signature");
+
+        if (fee > 0) {
+            require(trustedRSV.relayTransfer(from, msg.sender, fee), "fee transfer failed");
+            emit FeeTaken(from, msg.sender, fee);
+        }
+        require(trustedRSV.relayTransfer(from, to, amount));
+        emit TransferForwarded(sig, from, to, amount, fee);
+    }
+
+    // note that `fee` is not deducted from `amount`, and comes from the `spender` rather
+    // than `holder`.
+    function forwardTransferFrom(
+        bytes calldata sig, 
+        address spender,
+        address holder,
+        address to,
+        uint256 amount,
+        uint256 fee
+    )
+        external
+    {
+        bytes32 hash = keccak256(abi.encodePacked(
+            address(trustedRSV),
+            "transferFrom",
+            spender,
+            holder,
+            to,
+            amount,
+            fee,
+            nonce[spender]
+        ));
+        nonce[spender]++;
+
+        bytes32 ethMessageHash = ECDSA.toEthSignedMessageHash(hash);
+        address recoveredSigner = ECDSA.recover(ethMessageHash, sig);
+        require(recoveredSigner == spender, "invalid signature");
+
+        if (fee > 0) {
+            require(trustedRSV.relayTransfer(spender, msg.sender, fee), "fee transfer failed");
+            emit FeeTaken(spender, msg.sender, fee);
+        }
+        require(trustedRSV.relayTransferFrom(spender, holder, to, amount));
+        emit TransferFromForwarded(sig, spender, holder, to, amount, fee);
+    }
+
+    // note that `fee` is not deducted from `amount`.
+    function forwardApprove(
+        bytes calldata sig, 
+        address holder,
+        address spender,
+        uint256 amount,
+        uint256 fee
+    )
+        external
+    {
+        bytes32 hash = keccak256(abi.encodePacked(
+            address(trustedRSV),
+            "approve",
+            holder,
+            spender,
+            amount,
+            fee,
+            nonce[holder]
+        ));
+        nonce[holder]++;
+
+        bytes32 ethMessageHash = ECDSA.toEthSignedMessageHash(hash);
+        address recoveredSigner = ECDSA.recover(ethMessageHash, sig);
+        require(recoveredSigner == holder, "invalid signature");
+
+        if (fee > 0) {
+            require(trustedRSV.relayTransfer(holder, msg.sender, fee), "fee transfer failed");
+            emit FeeTaken(holder, msg.sender, fee);
+        }
+        require(trustedRSV.relayApprove(holder, spender, amount));
+        emit ApproveForwarded(sig, holder, spender, amount, fee);
+    }
+}

--- a/contracts/rsv/Relayer.sol
+++ b/contracts/rsv/Relayer.sol
@@ -4,6 +4,11 @@ import "./IRSV.sol";
 import "../ownership/Ownable.sol";
 import "../zeppelin/utils/ECDSA.sol";
 
+/**
+ * @title The Reserve Relayer Contract
+ * @dev A contract to support metatransactions via ECDSA signature verification.
+ *
+ */
 contract Relayer is Ownable {
 
     IRSV public trustedRSV;
@@ -25,7 +30,8 @@ contract Relayer is Ownable {
         trustedRSV = IRSV(newTrustedRSV);
     }
 
-    // note that `fee` is not deducted from `amount`.
+    /// Forwards a `transfer` call to the Reserve contract if the signature successfully passes ECDSA verification.
+    /// Note that `fee` is not deducted from `amount`, but separate.
     function forwardTransfer(
         bytes calldata sig, 
         address from,
@@ -57,8 +63,42 @@ contract Relayer is Ownable {
         emit TransferForwarded(sig, from, to, amount, fee);
     }
 
-    // note that `fee` is not deducted from `amount`, and comes from the `spender` rather
-    // than `holder`.
+    /// Forwards an `approve` call to the Reserve contract if the signature successfully passes ECDSA verification.
+    /// Note that `fee` is not deducted from `amount`, but separate.
+    function forwardApprove(
+        bytes calldata sig, 
+        address holder,
+        address spender,
+        uint256 amount,
+        uint256 fee
+    )
+        external
+    {
+        bytes32 hash = keccak256(abi.encodePacked(
+            address(trustedRSV),
+            "forwardApprove",
+            holder,
+            spender,
+            amount,
+            fee,
+            nonce[holder]
+        ));
+        nonce[holder]++;
+
+        address recoveredSigner = _recoverSignerAddress(hash, sig);
+        require(recoveredSigner == holder, "invalid signature");
+
+        if (fee > 0) {
+            require(trustedRSV.relayTransfer(holder, msg.sender, fee), "fee transfer failed");
+            emit FeeTaken(holder, msg.sender, fee);
+        }
+        require(trustedRSV.relayApprove(holder, spender, amount));
+        emit ApproveForwarded(sig, holder, spender, amount, fee);
+    }
+
+    /// Forwards a `transferFrom` call to the Reserve contract if the signature successfully passes ECDSA verification.
+    /// Note that `fee` is not deducted from `amount`, but separate.
+    /// Allowance checking is left up to the Reserve contract to do. 
     function forwardTransferFrom(
         bytes calldata sig, 
         address holder,
@@ -92,38 +132,7 @@ contract Relayer is Ownable {
         emit TransferFromForwarded(sig, holder, spender, to, amount, fee);
     }
 
-    // note that `fee` is not deducted from `amount`.
-    function forwardApprove(
-        bytes calldata sig, 
-        address holder,
-        address spender,
-        uint256 amount,
-        uint256 fee
-    )
-        external
-    {
-        bytes32 hash = keccak256(abi.encodePacked(
-            address(trustedRSV),
-            "forwardApprove",
-            holder,
-            spender,
-            amount,
-            fee,
-            nonce[holder]
-        ));
-        nonce[holder]++;
-
-        address recoveredSigner = _recoverSignerAddress(hash, sig);
-        require(recoveredSigner == holder, "invalid signature");
-
-        if (fee > 0) {
-            require(trustedRSV.relayTransfer(holder, msg.sender, fee), "fee transfer failed");
-            emit FeeTaken(holder, msg.sender, fee);
-        }
-        require(trustedRSV.relayApprove(holder, spender, amount));
-        emit ApproveForwarded(sig, holder, spender, amount, fee);
-    }
-
+    /// Recovers the signer's address from the hash and signature. 
     function _recoverSignerAddress(bytes32 hash, bytes memory sig) internal pure returns (address) {
       bytes32 ethMessageHash = ECDSA.toEthSignedMessageHash(hash);
       return ECDSA.recover(ethMessageHash, sig);

--- a/contracts/rsv/Reserve.sol
+++ b/contracts/rsv/Reserve.sol
@@ -4,7 +4,6 @@ import "../zeppelin/token/ERC20/IERC20.sol";
 import "../zeppelin/math/SafeMath.sol";
 import "../ownership/Ownable.sol";
 import "./ReserveEternalStorage.sol";
-import "./Relayer.sol";
 
 /**
  * @title An interface representing a contract that calculates transaction fees
@@ -34,7 +33,7 @@ contract Reserve is IERC20, Ownable {
     ITXFee public trustedTxFee;
 
     // Relayer
-    Relayer public trustedRelayer;
+    address public trustedRelayer;
 
     // Basic token data
     uint256 public totalSupply;
@@ -80,7 +79,7 @@ contract Reserve is IERC20, Ownable {
         paused = true;
 
         trustedTxFee = ITXFee(address(0));
-        trustedRelayer = Relayer(address(0));
+        trustedRelayer = address(0);
         trustedData = new ReserveEternalStorage();
         trustedData.nominateNewOwner(msg.sender);
     }

--- a/contracts/rsv/Reserve.sol
+++ b/contracts/rsv/Reserve.sol
@@ -320,7 +320,7 @@ contract Reserve is IERC20, Ownable {
     function relayTransferFrom(address holder, address spender, address to, uint256 value) 
         external 
         notPaused
-        only(address(trustedRelayer))
+        only(trustedRelayer)
         returns (bool)
     {
         _transfer(holder, to, value);

--- a/contracts/rsv/Reserve.sol
+++ b/contracts/rsv/Reserve.sol
@@ -288,7 +288,10 @@ contract Reserve is IERC20, Ownable {
         _approve(account, msg.sender, trustedData.allowed(account, msg.sender).sub(value));
     }
 
-    /// Relayed functions.
+    // ==== Relay functions === //
+    
+    /// Transfer `value` attotokens from `from` to `to`.
+    /// Callable only by the relay contract.
     function relayTransfer(address from, address to, uint256 value) 
         external 
         notPaused
@@ -299,6 +302,8 @@ contract Reserve is IERC20, Ownable {
         return true;
     }
 
+    /// Approve `value` attotokens to be spent by `spender` from `holder`.
+    /// Callable only by the relay contract.
     function relayApprove(address holder, address spender, uint256 value) 
         external 
         notPaused
@@ -309,6 +314,9 @@ contract Reserve is IERC20, Ownable {
         return true;
     }
 
+    /// `spender` transfers `value` attotokens from `holder` to `to`.
+    /// Requires allowance.
+    /// Callable only by the relay contract.
     function relayTransferFrom(address holder, address spender, address to, uint256 value) 
         external 
         notPaused

--- a/contracts/rsv/Reserve.sol
+++ b/contracts/rsv/Reserve.sol
@@ -300,17 +300,6 @@ contract Reserve is IERC20, Ownable {
         return true;
     }
 
-    function relayTransferFrom(address spender, address holder, address to, uint256 value) 
-        external 
-        notPaused
-        only(address(trustedRelayer))
-        returns (bool)
-    {
-        _transfer(holder, to, value);
-        _approve(holder, spender, trustedData.allowed(holder, spender).sub(value));
-        return true;
-    }
-
     function relayApprove(address holder, address spender, uint256 value) 
         external 
         notPaused
@@ -318,6 +307,17 @@ contract Reserve is IERC20, Ownable {
         returns (bool)
     {
         _approve(holder, spender, value);
+        return true;
+    }
+
+    function relayTransferFrom(address holder, address spender, address to, uint256 value) 
+        external 
+        notPaused
+        only(address(trustedRelayer))
+        returns (bool)
+    {
+        _transfer(holder, to, value);
+        _approve(holder, spender, trustedData.allowed(holder, spender).sub(value));
         return true;
     }
 

--- a/contracts/rsv/Reserve.sol
+++ b/contracts/rsv/Reserve.sol
@@ -307,7 +307,7 @@ contract Reserve is IERC20, Ownable {
     function relayApprove(address holder, address spender, uint256 value) 
         external 
         notPaused
-        only(address(trustedRelayer))
+        only(trustedRelayer)
         returns (bool)
     {
         _approve(holder, spender, value);

--- a/contracts/rsv/Reserve.sol
+++ b/contracts/rsv/Reserve.sol
@@ -295,7 +295,7 @@ contract Reserve is IERC20, Ownable {
     function relayTransfer(address from, address to, uint256 value) 
         external 
         notPaused
-        only(address(trustedRelayer))
+        only(trustedRelayer)
         returns (bool)
     {
         _transfer(from, to, value);

--- a/contracts/rsv/Reserve.sol
+++ b/contracts/rsv/Reserve.sol
@@ -133,7 +133,7 @@ contract Reserve is IERC20, Ownable {
 
     /// Change the contract that is able to do metatransactions.
     function changeRelayer(address newTrustedRelayer) external onlyOwner {
-        trustedRelayer = Relayer(newTrustedRelayer);
+        trustedRelayer = newTrustedRelayer;
         emit TrustedRelayerChanged(newTrustedRelayer);
     }
 

--- a/contracts/zeppelin/utils/ECDSA.sol
+++ b/contracts/zeppelin/utils/ECDSA.sol
@@ -1,0 +1,83 @@
+pragma solidity 0.5.7;
+
+/**
+ * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
+ *
+ * These functions can be used to verify that a message was signed by the holder
+ * of the private keys of a given address.
+ *
+ * Taken from OpenZeppelin: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol 
+ */
+library ECDSA {
+    /**
+     * @dev Returns the address that signed a hashed message (`hash`) with
+     * `signature`. This address can then be used for verification purposes.
+     *
+     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * this function rejects them by requiring the `s` value to be in the lower
+     * half order, and the `v` value to be either 27 or 28.
+     *
+     * IMPORTANT: `hash` _must_ be the result of a hash operation for the
+     * verification to be secure: it is possible to craft signatures that
+     * recover to arbitrary addresses for non-hashed data. A safe way to ensure
+     * this is by receiving a hash of the original message (which may otherwise
+     * be too long), and then calling {toEthSignedMessageHash} on it.
+     */
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+        // Check the signature length
+        if (signature.length != 65) {
+            revert("ECDSA: invalid signature length");
+        }
+
+        // Divide the signature in r, s and v variables
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        // ecrecover takes the signature parameters, and the only way to get them
+        // currently is to use assembly.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+
+        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            revert("ECDSA: invalid signature 's' value");
+        }
+
+        if (v != 27 && v != 28) {
+            revert("ECDSA: invalid signature 'v' value");
+        }
+
+        // If the signature is valid (and not malleable), return the signer address
+        address signer = ecrecover(hash, v, r, s);
+        require(signer != address(0), "ECDSA: invalid signature");
+
+        return signer;
+    }
+
+    /**
+     * @dev Returns an Ethereum Signed Message, created from a `hash`. This
+     * replicates the behavior of the
+     * https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign[`eth_sign`]
+     * JSON-RPC method.
+     *
+     * See {recover}.
+     */
+    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
+        // 32 is the length in bytes of hash,
+        // enforced by the type signature above
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+}

--- a/contracts/zeppelin/utils/ECDSA.sol
+++ b/contracts/zeppelin/utils/ECDSA.sol
@@ -6,7 +6,9 @@ pragma solidity 0.5.7;
  * These functions can be used to verify that a message was signed by the holder
  * of the private keys of a given address.
  *
- * All credit to OpenZeppelin. Taken from: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol.
+ * All credit to OpenZeppelin. Taken from: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol at commit 65e4ffde586ec89af3b7e9140bdc9235d1254853.
+ *
+ * Note that the solidity version has been changed from ^0.6.0 to 0.5.7. 
  */
 library ECDSA {
     /**

--- a/contracts/zeppelin/utils/ECDSA.sol
+++ b/contracts/zeppelin/utils/ECDSA.sol
@@ -5,6 +5,8 @@ pragma solidity 0.5.7;
  *
  * These functions can be used to verify that a message was signed by the holder
  * of the private keys of a given address.
+ *
+ * All credit to OpenZeppelin. Taken from: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol.
  */
 library ECDSA {
     /**
@@ -60,7 +62,7 @@ library ECDSA {
 
         // If the signature is valid (and not malleable), return the signer address
         address signer = ecrecover(hash, v, r, s);
-        require(signer != address(0), "ECDSA: invalid signature");
+        // require(signer != address(0), "ECDSA: invalid signature");
 
         return signer;
     }

--- a/contracts/zeppelin/utils/ECDSA.sol
+++ b/contracts/zeppelin/utils/ECDSA.sol
@@ -5,8 +5,6 @@ pragma solidity 0.5.7;
  *
  * These functions can be used to verify that a message was signed by the holder
  * of the private keys of a given address.
- *
- * Taken from OpenZeppelin: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol 
  */
 library ECDSA {
     /**

--- a/go.mod
+++ b/go.mod
@@ -12,15 +12,12 @@ require (
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/rjeczalik/notify v0.9.2 // indirect

--- a/tests/base.go
+++ b/tests/base.go
@@ -93,18 +93,14 @@ func (s *TestSuite) requireTxWithStrictEvents(tx *types.Transaction, err error) 
 	// and assert that the transaction generates those events.
 	return func(assertEvent ...fmt.Stringer) {
 		if s.Equal(len(assertEvent), len(receipt.Logs), "did not get the expected number of events") {
-			for _, wantEvent := range assertEvent {
-				found := false
-				for _, log := range receipt.Logs {
-					parser := s.logParsers[log.Address]
-					if s.NotNil(parser, "got an event from an unexpected contract address: "+log.Address.Hex()) {
-						gotEvent, err := parser.ParseLog(log)
-						if err == nil && gotEvent.String() == wantEvent.String() {
-							found = true
-						}
+			for i, wantEvent := range assertEvent {
+				parser := s.logParsers[receipt.Logs[i].Address]
+				if s.NotNil(parser, "got an event from an unexpected contract address: "+receipt.Logs[i].Address.Hex()) {
+					gotEvent, err := parser.ParseLog(receipt.Logs[i])
+					if s.NoErrorf(err, "parsing event %v", i) {
+						s.Equal(wantEvent.String(), gotEvent.String())
 					}
 				}
-				s.Equal(true, found)
 			}
 		}
 	}

--- a/tests/base.go
+++ b/tests/base.go
@@ -93,14 +93,18 @@ func (s *TestSuite) requireTxWithStrictEvents(tx *types.Transaction, err error) 
 	// and assert that the transaction generates those events.
 	return func(assertEvent ...fmt.Stringer) {
 		if s.Equal(len(assertEvent), len(receipt.Logs), "did not get the expected number of events") {
-			for i, wantEvent := range assertEvent {
-				parser := s.logParsers[receipt.Logs[i].Address]
-				if s.NotNil(parser, "got an event from an unexpected contract address: "+receipt.Logs[i].Address.Hex()) {
-					gotEvent, err := parser.ParseLog(receipt.Logs[i])
-					if s.NoErrorf(err, "parsing event %v", i) {
-						s.Equal(wantEvent.String(), gotEvent.String())
+			for _, wantEvent := range assertEvent {
+				found := false
+				for _, log := range receipt.Logs {
+					parser := s.logParsers[log.Address]
+					if s.NotNil(parser, "got an event from an unexpected contract address: "+log.Address.Hex()) {
+						gotEvent, err := parser.ParseLog(log)
+						if err == nil && gotEvent.String() == wantEvent.String() {
+							found = true
+						}
 					}
 				}
+				s.Equal(true, found)
 			}
 		}
 	}

--- a/tests/relayer_test.go
+++ b/tests/relayer_test.go
@@ -1,0 +1,517 @@
+// +build all
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/reserve-protocol/rsv-beta/abi"
+)
+
+func TestRelayer(t *testing.T) {
+	suite.Run(t, new(RelayerSuite))
+}
+
+type RelayerSuite struct {
+	TestSuite
+
+	relayer        *abi.Relayer
+	relayerAddress common.Address
+}
+
+var (
+	// Compile-time check that RelayerSuite implements the interfaces we think it does.
+	// If it does not implement these interfaces, then the corresponding setup and teardown
+	// functions will not actually run.
+	_ suite.BeforeTest       = &RelayerSuite{}
+	_ suite.SetupAllSuite    = &RelayerSuite{}
+	_ suite.TearDownAllSuite = &RelayerSuite{}
+)
+
+// SetupSuite runs once, before all of the tests in the suite.
+func (s *RelayerSuite) SetupSuite() {
+	s.setup()
+}
+
+// BeforeTest runs before each test in the suite.
+func (s *RelayerSuite) BeforeTest(suiteName, testName string) {
+	// Re-deploy Reserve and store a handle to the Go binding and the contract address.
+	reserveAddress, tx, reserve, err := abi.DeployReserve(s.signer, s.node)
+
+	s.logParsers = map[common.Address]logParser{
+		reserveAddress: reserve,
+	}
+
+	s.requireTx(tx, err)(
+		abi.ReserveOwnershipTransferred{PreviousOwner: zeroAddress(), NewOwner: s.owner.address()},
+	)
+
+	// Confirm it begins paused.
+	paused, err := reserve.Paused(nil)
+	s.Require().NoError(err)
+	s.Equal(true, paused)
+
+	// Unpause.
+	s.requireTxWithStrictEvents(reserve.Unpause(s.signer))(
+		abi.ReserveUnpaused{Account: s.owner.address()},
+	)
+
+	s.reserve = reserve
+	s.reserveAddress = reserveAddress
+
+	// Get the Go binding and contract address for the new ReserveEternalStorage contract.
+	s.eternalStorageAddress, err = s.reserve.GetEternalStorageAddress(nil)
+	s.Require().NoError(err)
+	s.eternalStorage, err = abi.NewReserveEternalStorage(s.eternalStorageAddress, s.node)
+	s.Require().NoError(err)
+
+	s.logParsers[s.eternalStorageAddress] = s.eternalStorage
+
+	// Accept ownership.
+	s.requireTxWithStrictEvents(s.eternalStorage.AcceptOwnership(s.signer))(
+		abi.ReserveEternalStorageOwnershipTransferred{
+			PreviousOwner: s.reserveAddress, NewOwner: s.owner.address(),
+		},
+	)
+
+	deployerAddress := s.owner.address()
+
+	s.assertRSVTotalSupply(bigInt(0))
+
+	// Make the deployment account a minter, pauser, and freezer.
+	s.requireTxWithStrictEvents(s.reserve.ChangeMinter(s.signer, deployerAddress))(
+		abi.ReserveMinterChanged{NewMinter: deployerAddress},
+	)
+	s.requireTxWithStrictEvents(s.reserve.ChangePauser(s.signer, deployerAddress))(
+		abi.ReservePauserChanged{NewPauser: deployerAddress},
+	)
+	s.requireTxWithStrictEvents(s.reserve.ChangeFeeRecipient(s.signer, deployerAddress))(
+		abi.ReserveFeeRecipientChanged{NewFeeRecipient: deployerAddress},
+	)
+
+	relayerAddress, tx, relayer, err := abi.DeployRelayer(s.signer, s.node, s.reserveAddress)
+
+	s.requireTx(tx, err)()
+
+	s.relayer = relayer
+	s.relayerAddress = relayerAddress
+
+	s.logParsers[s.relayerAddress] = s.relayer
+
+	// Make sure Reserve address set correctly.
+	deployedRSVAddress, err := s.relayer.TrustedRSV(nil)
+	s.Require().NoError(err)
+	s.Equal(deployedRSVAddress, s.reserveAddress)
+
+	// Set Reserve's trusted relayer address correctly.
+	s.requireTxWithStrictEvents(s.reserve.ChangeRelayer(s.signer, s.relayerAddress))(
+		abi.ReserveTrustedRelayerChanged{NewTrustedRelayer: s.relayerAddress},
+	)
+
+	// Apparently `ecrecover` is only available on private blockchains after
+	// sending wei to its address, which is address `1`.
+	// See here: https://solidity.readthedocs.io/en/v0.6.4/units-and-global-variables.html
+	nonce, err := s.node.PendingNonceAt(context.Background(), s.account[0].address())
+	s.Require().NoError(err)
+
+	tx, err = types.SignTx(
+		types.NewTransaction(nonce, common.BytesToAddress([]byte{1}), bigInt(1), 210000, bigInt(1), nil),
+		types.HomesteadSigner{},
+		s.account[0].key,
+	)
+	s.node.SendTransaction(context.Background(), tx)
+	s.requireTx(tx, err)
+}
+
+func (s *RelayerSuite) TestDeploy() {}
+
+// TestTransfer checks that someone with RSV can send RSV to a recipient through a relayer.
+func (s *RelayerSuite) TestTransfer() {
+	relayer := s.account[4]
+	sender := s.account[1]
+	recipient := common.BigToAddress(bigInt(1))
+	amount := bigInt(100)
+
+	// Mint to sender.
+	s.requireTxWithStrictEvents(s.reserve.Mint(s.signer, sender.address(), amount))(
+		mintingTransfer(sender.address(), amount),
+	)
+
+	// Check that balances are as expected.
+	s.assertRSVBalance(sender.address(), amount)
+	s.assertRSVBalance(recipient, bigInt(0))
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+
+	nonce, err := s.relayer.Nonce(nil, sender.address())
+	s.Require().NoError(err)
+
+	hash := s.transferHash(sender.address(), recipient, amount, bigInt(0), nonce)
+	sig, err := crypto.Sign(hash, sender.key)
+	s.Require().NoError(err)
+
+	// Add 27 to 65th byte.
+	sig = addToLastByte(sig)
+
+	// Relay transfer tx
+	s.requireTxWithStrictEvents(s.relayer.ForwardTransfer(signer(relayer), sig, sender.address(), recipient, amount, bigInt(0)))(
+		abi.RelayerTransferForwarded{
+			Sig:    sig,
+			From:   sender.address(),
+			To:     recipient,
+			Amount: amount,
+			Fee:    bigInt(0),
+		},
+		abi.ReserveTransfer{
+			From:  sender.address(),
+			To:    recipient,
+			Value: amount,
+		},
+	)
+
+	// Check that balances are as expected.
+	s.assertRSVBalance(sender.address(), bigInt(0))
+	s.assertRSVBalance(recipient, amount)
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+}
+
+// TestTransferFailsFromScammer checks that other accounts cannot
+func (s *RelayerSuite) TestTransferFailsFromScammer() {
+	relayer := s.account[4]
+	sender := s.account[1]
+	scammer := s.account[2]
+	recipient := common.BigToAddress(bigInt(1))
+	amount := bigInt(100)
+
+	// Mint to sender.
+	s.requireTxWithStrictEvents(s.reserve.Mint(s.signer, sender.address(), amount))(
+		mintingTransfer(sender.address(), amount),
+	)
+
+	// Check that balances are as expected.
+	s.assertRSVBalance(sender.address(), amount)
+	s.assertRSVBalance(recipient, bigInt(0))
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+
+	nonce, err := s.relayer.Nonce(nil, sender.address())
+	s.Require().NoError(err)
+
+	hash := s.transferHash(sender.address(), recipient, amount, bigInt(0), nonce)
+	sig, err := crypto.Sign(hash, scammer.key)
+	s.Require().NoError(err)
+
+	// Add 27 to 65th byte.
+	sig = addToLastByte(sig)
+
+	// Relay transfer tx
+	s.requireTxFails(s.relayer.ForwardTransfer(signer(relayer), sig, sender.address(), recipient, amount, bigInt(0)))
+
+	// Check that balances haven't changed.
+	s.assertRSVBalance(sender.address(), amount)
+	s.assertRSVBalance(recipient, bigInt(0))
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+}
+
+func (s *RelayerSuite) TestApproveAndTransferFrom() {
+	relayer := s.account[4]
+	holder := s.account[1]
+	spender := s.account[2]
+	recipient := common.BigToAddress(bigInt(1))
+	amount := bigInt(100)
+
+	// Mint to holder.
+	s.requireTxWithStrictEvents(s.reserve.Mint(s.signer, holder.address(), amount))(
+		mintingTransfer(holder.address(), amount),
+	)
+
+	// Check that balances and allowances are as expected.
+	s.assertRSVBalance(holder.address(), amount)
+	s.assertRSVBalance(spender.address(), bigInt(0))
+	s.assertRSVBalance(recipient, bigInt(0))
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVAllowance(holder.address(), spender.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+
+	nonce, err := s.relayer.Nonce(nil, holder.address())
+	s.Require().NoError(err)
+
+	hash := s.approveHash(holder.address(), spender.address(), amount, bigInt(0), nonce)
+	sig, err := crypto.Sign(hash, holder.key)
+	s.Require().NoError(err)
+
+	// Add 27 to 65th byte.
+	sig = addToLastByte(sig)
+
+	// Relay approve tx.
+	s.requireTxWithStrictEvents(s.relayer.ForwardApprove(signer(relayer), sig, holder.address(), spender.address(), amount, bigInt(0)))(
+		abi.RelayerApproveForwarded{
+			Sig:     sig,
+			Holder:  holder.address(),
+			Spender: spender.address(),
+			Amount:  amount,
+			Fee:     bigInt(0),
+		},
+		abi.ReserveApproval{
+			Owner:   holder.address(),
+			Spender: spender.address(),
+			Value:   amount,
+		},
+	)
+
+	// Check that the spender has allowance
+	s.assertRSVAllowance(holder.address(), spender.address(), amount)
+
+	// ==== SECOND RELAY === //
+
+	nonce, err = s.relayer.Nonce(nil, spender.address())
+	s.Require().NoError(err)
+
+	hash = s.transferFromHash(holder.address(), spender.address(), recipient, amount, bigInt(0), nonce)
+	sig, err = crypto.Sign(hash, spender.key)
+	s.Require().NoError(err)
+
+	// Add 27 to 65th byte.
+	sig = addToLastByte(sig)
+
+	// Relay approve tx.
+	s.requireTxWithStrictEvents(s.relayer.ForwardTransferFrom(signer(relayer), sig, holder.address(), spender.address(), recipient, amount, bigInt(0)))(
+		abi.RelayerTransferFromForwarded{
+			Sig:     sig,
+			Holder:  holder.address(),
+			Spender: spender.address(),
+			To:      recipient,
+			Amount:  amount,
+			Fee:     bigInt(0),
+		},
+		abi.ReserveTransfer{
+			From:  holder.address(),
+			To:    recipient,
+			Value: amount,
+		},
+		abi.ReserveApproval{
+			Owner:   holder.address(),
+			Spender: spender.address(),
+			Value:   bigInt(0),
+		},
+	)
+
+	// Check that the spender has no allowance and that balances have changed.
+	s.assertRSVAllowance(holder.address(), spender.address(), bigInt(0))
+	s.assertRSVBalance(holder.address(), bigInt(0))
+	s.assertRSVBalance(spender.address(), bigInt(0))
+	s.assertRSVBalance(recipient, amount)
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+}
+
+func (s *RelayerSuite) TestApproveFailsFromScammer() {
+	relayer := s.account[4]
+	holder := s.account[1]
+	spender := s.account[2]
+	scammer := s.account[2] // the scammer is the spender!
+	recipient := common.BigToAddress(bigInt(1))
+	amount := bigInt(100)
+
+	// Mint to holder.
+	s.requireTxWithStrictEvents(s.reserve.Mint(s.signer, holder.address(), amount))(
+		mintingTransfer(holder.address(), amount),
+	)
+
+	// Check that balances and allowances are as expected.
+	s.assertRSVBalance(holder.address(), amount)
+	s.assertRSVBalance(spender.address(), bigInt(0))
+	s.assertRSVBalance(recipient, bigInt(0))
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVAllowance(holder.address(), spender.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+
+	nonce, err := s.relayer.Nonce(nil, holder.address())
+	s.Require().NoError(err)
+
+	hash := s.approveHash(holder.address(), spender.address(), amount, bigInt(0), nonce)
+	sig, err := crypto.Sign(hash, scammer.key)
+	s.Require().NoError(err)
+
+	// Add 27 to 65th byte.
+	sig = addToLastByte(sig)
+
+	// Relay approve tx.
+	s.requireTxFails(s.relayer.ForwardApprove(signer(relayer), sig, holder.address(), spender.address(), amount, bigInt(0)))
+
+	// Check that the spender did not get allowance.
+	s.assertRSVAllowance(holder.address(), spender.address(), bigInt(0))
+}
+
+func (s *RelayerSuite) TestTransferFromFailsFromScammer() {
+	relayer := s.account[4]
+	holder := s.account[1]
+	spender := s.account[2]
+	scammer := s.account[3]
+	recipient := common.BigToAddress(bigInt(1))
+	amount := bigInt(100)
+
+	// Mint to holder.
+	s.requireTxWithStrictEvents(s.reserve.Mint(s.signer, holder.address(), amount))(
+		mintingTransfer(holder.address(), amount),
+	)
+
+	// Check that balances and allowances are as expected.
+	s.assertRSVBalance(holder.address(), amount)
+	s.assertRSVBalance(spender.address(), bigInt(0))
+	s.assertRSVBalance(recipient, bigInt(0))
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVAllowance(holder.address(), spender.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+
+	nonce, err := s.relayer.Nonce(nil, holder.address())
+	s.Require().NoError(err)
+
+	hash := s.approveHash(holder.address(), spender.address(), amount, bigInt(0), nonce)
+	sig, err := crypto.Sign(hash, holder.key)
+	s.Require().NoError(err)
+
+	// Add 27 to 65th byte.
+	sig = addToLastByte(sig)
+
+	// Relay approve tx.
+	s.requireTxWithStrictEvents(s.relayer.ForwardApprove(signer(relayer), sig, holder.address(), spender.address(), amount, bigInt(0)))(
+		abi.RelayerApproveForwarded{
+			Sig:     sig,
+			Holder:  holder.address(),
+			Spender: spender.address(),
+			Amount:  amount,
+			Fee:     bigInt(0),
+		},
+		abi.ReserveApproval{
+			Owner:   holder.address(),
+			Spender: spender.address(),
+			Value:   amount,
+		},
+	)
+
+	// Check that the spender has allowance
+	s.assertRSVAllowance(holder.address(), spender.address(), amount)
+
+	// ==== SECOND RELAY, this one should fail === //
+
+	nonce, err = s.relayer.Nonce(nil, spender.address())
+	s.Require().NoError(err)
+
+	hash = s.transferFromHash(holder.address(), spender.address(), recipient, amount, bigInt(0), nonce)
+	sig, err = crypto.Sign(hash, scammer.key)
+	s.Require().NoError(err)
+
+	// Add 27 to 65th byte.
+	sig = addToLastByte(sig)
+
+	// Relay approve tx.
+	s.requireTxFails(s.relayer.ForwardTransferFrom(signer(relayer), sig, holder.address(), spender.address(), recipient, amount, bigInt(0)))
+
+	// Check that the spender still has allowance and that balances haven't changed.
+	s.assertRSVAllowance(holder.address(), spender.address(), amount)
+	s.assertRSVBalance(holder.address(), amount)
+	s.assertRSVBalance(spender.address(), bigInt(0))
+	s.assertRSVBalance(recipient, bigInt(0))
+	s.assertRSVBalance(s.owner.address(), bigInt(0))
+	s.assertRSVTotalSupply(amount)
+}
+
+func (s *RelayerSuite) TestSetRSVProtected() {
+	scammer := s.account[1]
+
+	s.requireTxFails(s.relayer.SetRSV(signer(scammer), scammer.address()))
+
+	trustedRSV, err := s.relayer.TrustedRSV(nil)
+	s.Require().NoError(err)
+
+	s.Equal(s.reserveAddress.String(), trustedRSV.String())
+}
+
+// ========================================== HELPERS ========================================= //
+
+func (s *RelayerSuite) transferHash(
+	from common.Address,
+	to common.Address,
+	amount *big.Int,
+	fee *big.Int,
+	nonce *big.Int,
+) []byte {
+	interimHash := crypto.Keccak256Hash(
+		s.reserveAddress.Bytes(),
+		[]byte("forwardTransfer"),
+		from.Bytes(),
+		to.Bytes(),
+		common.LeftPadBytes(amount.Bytes(), 32),
+		common.LeftPadBytes(fee.Bytes(), 32),
+		common.LeftPadBytes(nonce.Bytes(), 32),
+	)
+	return crypto.Keccak256Hash(
+		[]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%v", len(interimHash))),
+		interimHash.Bytes(),
+	).Bytes()
+}
+
+func (s *RelayerSuite) transferFromHash(
+	holder common.Address,
+	spender common.Address,
+	to common.Address,
+	amount *big.Int,
+	fee *big.Int,
+	nonce *big.Int,
+) []byte {
+	interimHash := crypto.Keccak256Hash(
+		s.reserveAddress.Bytes(),
+		[]byte("forwardTransferFrom"),
+		holder.Bytes(),
+		spender.Bytes(),
+		to.Bytes(),
+		common.LeftPadBytes(amount.Bytes(), 32),
+		common.LeftPadBytes(fee.Bytes(), 32),
+		common.LeftPadBytes(nonce.Bytes(), 32),
+	)
+	return crypto.Keccak256Hash(
+		[]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%v", len(interimHash))),
+		interimHash.Bytes(),
+	).Bytes()
+}
+
+func (s *RelayerSuite) approveHash(
+	holder common.Address,
+	spender common.Address,
+	amount *big.Int,
+	fee *big.Int,
+	nonce *big.Int,
+) []byte {
+	interimHash := crypto.Keccak256Hash(
+		s.reserveAddress.Bytes(),
+		[]byte("forwardApprove"),
+		holder.Bytes(),
+		spender.Bytes(),
+		common.LeftPadBytes(amount.Bytes(), 32),
+		common.LeftPadBytes(fee.Bytes(), 32),
+		common.LeftPadBytes(nonce.Bytes(), 32),
+	)
+	return crypto.Keccak256Hash(
+		[]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%v", len(interimHash))),
+		interimHash.Bytes(),
+	).Bytes()
+}
+
+func addToLastByte(sig []byte) []byte {
+	v := []byte{27}
+	v[0] = v[0] + sig[64]
+	sig = sig[:64]
+	sig = append(sig, v...)
+	return sig
+}

--- a/tests/relayer_test.go
+++ b/tests/relayer_test.go
@@ -162,17 +162,17 @@ func (s *RelayerSuite) TestTransfer() {
 
 	// Relay transfer tx
 	s.requireTxWithStrictEvents(s.relayer.ForwardTransfer(signer(relayer), sig, sender.address(), recipient, amount, bigInt(0)))(
+		abi.ReserveTransfer{
+			From:  sender.address(),
+			To:    recipient,
+			Value: amount,
+		},
 		abi.RelayerTransferForwarded{
 			Sig:    sig,
 			From:   sender.address(),
 			To:     recipient,
 			Amount: amount,
 			Fee:    bigInt(0),
-		},
-		abi.ReserveTransfer{
-			From:  sender.address(),
-			To:    recipient,
-			Value: amount,
 		},
 	)
 
@@ -215,12 +215,10 @@ func (s *RelayerSuite) TestTransferWithFee() {
 
 	// Now transaction should complete
 	s.requireTxWithStrictEvents(s.relayer.ForwardTransfer(signer(relayer), sig, sender.address(), recipient, amount, fee))(
-		abi.RelayerTransferForwarded{
-			Sig:    sig,
-			From:   sender.address(),
-			To:     recipient,
-			Amount: amount,
-			Fee:    fee,
+		abi.ReserveTransfer{
+			From:  sender.address(),
+			To:    relayer.address(),
+			Value: fee,
 		},
 		abi.RelayerFeeTaken{
 			From:  sender.address(),
@@ -232,10 +230,12 @@ func (s *RelayerSuite) TestTransferWithFee() {
 			To:    recipient,
 			Value: amount,
 		},
-		abi.ReserveTransfer{
-			From:  sender.address(),
-			To:    relayer.address(),
-			Value: fee,
+		abi.RelayerTransferForwarded{
+			Sig:    sig,
+			From:   sender.address(),
+			To:     recipient,
+			Amount: amount,
+			Fee:    fee,
 		},
 	)
 
@@ -313,17 +313,17 @@ func (s *RelayerSuite) TestApproveAndTransferFrom() {
 
 	// Relay approve tx.
 	s.requireTxWithStrictEvents(s.relayer.ForwardApprove(signer(relayer), sig, holder.address(), spender.address(), amount, bigInt(0)))(
+		abi.ReserveApproval{
+			Owner:   holder.address(),
+			Spender: spender.address(),
+			Value:   amount,
+		},
 		abi.RelayerApproveForwarded{
 			Sig:     sig,
 			Holder:  holder.address(),
 			Spender: spender.address(),
 			Amount:  amount,
 			Fee:     bigInt(0),
-		},
-		abi.ReserveApproval{
-			Owner:   holder.address(),
-			Spender: spender.address(),
-			Value:   amount,
 		},
 	)
 
@@ -344,14 +344,6 @@ func (s *RelayerSuite) TestApproveAndTransferFrom() {
 
 	// Relay approve tx.
 	s.requireTxWithStrictEvents(s.relayer.ForwardTransferFrom(signer(relayer), sig, holder.address(), spender.address(), recipient, amount, bigInt(0)))(
-		abi.RelayerTransferFromForwarded{
-			Sig:     sig,
-			Holder:  holder.address(),
-			Spender: spender.address(),
-			To:      recipient,
-			Amount:  amount,
-			Fee:     bigInt(0),
-		},
 		abi.ReserveTransfer{
 			From:  holder.address(),
 			To:    recipient,
@@ -361,6 +353,14 @@ func (s *RelayerSuite) TestApproveAndTransferFrom() {
 			Owner:   holder.address(),
 			Spender: spender.address(),
 			Value:   bigInt(0),
+		},
+		abi.RelayerTransferFromForwarded{
+			Sig:     sig,
+			Holder:  holder.address(),
+			Spender: spender.address(),
+			To:      recipient,
+			Amount:  amount,
+			Fee:     bigInt(0),
 		},
 	)
 
@@ -394,12 +394,10 @@ func (s *RelayerSuite) TestApproveWithFee() {
 	s.Require().NoError(err)
 	sig = addToLastByte(sig)
 	s.requireTxWithStrictEvents(s.relayer.ForwardApprove(signer(relayer), sig, holder.address(), spender.address(), amount, fee))(
-		abi.RelayerApproveForwarded{
-			Sig:     sig,
-			Holder:  holder.address(),
-			Spender: spender.address(),
-			Amount:  amount,
-			Fee:     fee,
+		abi.ReserveTransfer{
+			From:  holder.address(),
+			To:    relayer.address(),
+			Value: fee,
 		},
 		abi.RelayerFeeTaken{
 			From:  holder.address(),
@@ -411,10 +409,12 @@ func (s *RelayerSuite) TestApproveWithFee() {
 			Spender: spender.address(),
 			Value:   amount,
 		},
-		abi.ReserveTransfer{
-			From:  holder.address(),
-			To:    relayer.address(),
-			Value: fee,
+		abi.RelayerApproveForwarded{
+			Sig:     sig,
+			Holder:  holder.address(),
+			Spender: spender.address(),
+			Amount:  amount,
+			Fee:     fee,
 		},
 	)
 
@@ -499,13 +499,10 @@ func (s *RelayerSuite) TestTransferFromWithFee() {
 	s.Require().NoError(err)
 	sig = addToLastByte(sig)
 	s.requireTxWithStrictEvents(s.relayer.ForwardTransferFrom(signer(relayer), sig, holder.address(), spender.address(), recipient.address(), amount, fee))(
-		abi.RelayerTransferFromForwarded{
-			Sig:     sig,
-			Holder:  holder.address(),
-			Spender: spender.address(),
-			To:      recipient.address(),
-			Amount:  amount,
-			Fee:     fee,
+		abi.ReserveTransfer{
+			From:  spender.address(),
+			To:    relayer.address(),
+			Value: fee,
 		},
 		abi.RelayerFeeTaken{
 			From:  spender.address(),
@@ -517,15 +514,18 @@ func (s *RelayerSuite) TestTransferFromWithFee() {
 			To:    recipient.address(),
 			Value: amount,
 		},
-		abi.ReserveTransfer{
-			From:  spender.address(),
-			To:    relayer.address(),
-			Value: fee,
-		},
 		abi.ReserveApproval{
 			Owner:   holder.address(),
 			Spender: spender.address(),
 			Value:   bigInt(0),
+		},
+		abi.RelayerTransferFromForwarded{
+			Sig:     sig,
+			Holder:  holder.address(),
+			Spender: spender.address(),
+			To:      recipient.address(),
+			Amount:  amount,
+			Fee:     fee,
 		},
 	)
 
@@ -569,17 +569,17 @@ func (s *RelayerSuite) TestTransferFromFailsFromScammer() {
 
 	// Relay approve tx.
 	s.requireTxWithStrictEvents(s.relayer.ForwardApprove(signer(relayer), sig, holder.address(), spender.address(), amount, bigInt(0)))(
+		abi.ReserveApproval{
+			Owner:   holder.address(),
+			Spender: spender.address(),
+			Value:   amount,
+		},
 		abi.RelayerApproveForwarded{
 			Sig:     sig,
 			Holder:  holder.address(),
 			Spender: spender.address(),
 			Amount:  amount,
 			Fee:     bigInt(0),
-		},
-		abi.ReserveApproval{
-			Owner:   holder.address(),
-			Spender: spender.address(),
-			Value:   amount,
 		},
 	)
 


### PR DESCRIPTION
Adds support for metatransactions by any party to RSV via a permissioned relayer contract. 

The relayer contract is the only account that is able to cause transfers or approvals for an account not equal to `msg.sender`. 

The relayer contract implements ECDSA signature verification in order to determine that the signer did in fact authorize the state change. This allows a third-party (anyone, in this design), to pay the gas fees. 