### PR TITLE
Changes from CertiK April 2020 audit 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ flat: $(flat)
 test: abi
 	go test ./tests -tags all
 
+testRelay: abi
+	go test ./tests/base.go ./tests/relayer_test.go
+
 fuzz: abi
 	go test ./tests -v -tags fuzz -args -decimals=$(decimals) -runs=$(runs)
 

--- a/contracts/rsv/Relayer.sol
+++ b/contracts/rsv/Relayer.sol
@@ -77,7 +77,10 @@ contract Relayer is Ownable {
 
         _takeFee(from, fee);
 
-        require(trustedRSV.relayTransfer(from, to, amount));
+        require(
+            trustedRSV.relayTransfer(from, to, amount), 
+            "Reserve.sol relayTransfer failed"
+        );
         emit TransferForwarded(sig, from, to, amount, fee);
     }
 
@@ -108,7 +111,10 @@ contract Relayer is Ownable {
 
         _takeFee(holder, fee);
 
-        require(trustedRSV.relayApprove(holder, spender, amount));
+        require(
+            trustedRSV.relayApprove(holder, spender, amount), 
+            "Reserve.sol relayApprove failed"
+        );
         emit ApproveForwarded(sig, holder, spender, amount, fee);
     }
 
@@ -142,7 +148,10 @@ contract Relayer is Ownable {
 
         _takeFee(spender, fee);
 
-        require(trustedRSV.relayTransferFrom(holder, spender, to, amount));
+        require(
+            trustedRSV.relayTransferFrom(holder, spender, to, amount), 
+            "Reserve.sol relayTransfer failed"
+        );
         emit TransferFromForwarded(sig, holder, spender, to, amount, fee);
     }
 

--- a/contracts/rsv/Relayer.sol
+++ b/contracts/rsv/Relayer.sol
@@ -166,7 +166,7 @@ contract Relayer is Ownable {
 
     /// Transfer a fee from payer to sender.
     function _takeFee(address payer, uint256 fee) internal {
-        if (fee > 0) {
+        if (fee != 0) {
             require(trustedRSV.relayTransfer(payer, msg.sender, fee), "fee transfer failed");
             emit FeeTaken(payer, msg.sender, fee);
         }


### PR DESCRIPTION
1. Adds messages to requires
2. Adds a new make target for specifically relay tests
3. Replaces a uint `>0` with `!=0` 